### PR TITLE
Stopfix - fix to continuous autoplay of radio bot

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -81,6 +81,7 @@ client.on('voiceStateUpdate', (oldState, newState) => {
 
     if (wasDisconnected) {
         console.log('Bot was disconnected. Attempting to rejoin...');
+        // disabled the automatic rejoin for now
         // joinVoiceChannelHandler();
     }
 });

--- a/src/bot.js
+++ b/src/bot.js
@@ -81,7 +81,7 @@ client.on('voiceStateUpdate', (oldState, newState) => {
 
     if (wasDisconnected) {
         console.log('Bot was disconnected. Attempting to rejoin...');
-        joinVoiceChannelHandler();
+        // joinVoiceChannelHandler();
     }
 });
 


### PR DESCRIPTION
1.  Temporarily deleted the recursion of the JoinAudioChannel function to allow users to stop the audio bot in Discord without automatically reappearing in seconds.  It will only reappear when the /play command is called.
2. Folder structure for songs is modified for playlist, mixttape. and band.