### PR TITLE
Add POST /play-crew API endpoint

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,10 @@
 const express = require('express');
-const { joinVoiceChannel } = require('@discordjs/voice');
+const { joinVoiceChannel, createAudioPlayer, createAudioResource, AudioPlayerStatus, VoiceConnectionStatus, entersState } = require('@discordjs/voice');
+const fs = require('fs');
+const path = require('path');
+const state = require('./state');
 const { startMixtape } = require('./services/mixtape-service');
+const { CREWS, crewFolder } = require('./commands/crew');
 
 function createApiServer(client) {
     const app = express();
@@ -49,6 +53,122 @@ function createApiServer(client) {
             res.json(result);
         } catch (err) {
             console.error('API /start-mixtape error:', err);
+            res.status(500).json({ error: err.message });
+        }
+    });
+
+    // Play crew theme song
+    app.post('/play-crew', async (req, res) => {
+        try {
+            const { crew } = req.body;
+            if (!crew) {
+                return res.status(400).json({ error: 'Missing "crew" field in request body', validCrews: CREWS });
+            }
+
+            // Case-insensitive crew lookup
+            const matchedCrew = CREWS.find(c => c.toLowerCase() === crew.toLowerCase());
+            if (!matchedCrew) {
+                return res.status(400).json({ error: `Invalid crew "${crew}"`, validCrews: CREWS });
+            }
+
+            const guild = client.guilds.cache.get(GUILD_ID);
+            if (!guild) {
+                return res.status(500).json({ error: 'Guild not found' });
+            }
+
+            const channelId = req.body.channelId || VOICE_CHANNEL_ID;
+            const voiceChannel = guild.channels.cache.get(channelId);
+            if (!voiceChannel) {
+                return res.status(400).json({ error: 'Voice channel not found' });
+            }
+
+            // Resolve crew song folder and find audio files
+            const targetFolder = path.join(crewFolder, matchedCrew);
+            if (!fs.existsSync(targetFolder)) {
+                return res.status(404).json({ error: `No song folder found for crew "${matchedCrew}"` });
+            }
+
+            const supportedExtensions = ['.mp3', '.wav', '.ogg', '.flac', '.aac', '.m4a', '.wma'];
+            const allFiles = fs.readdirSync(targetFolder).filter(file =>
+                supportedExtensions.includes(path.extname(file).toLowerCase())
+            );
+
+            if (allFiles.length === 0) {
+                return res.status(404).json({ error: `No audio files found for crew "${matchedCrew}"` });
+            }
+
+            // Stop any existing playback
+            if (state.player) {
+                state.player.removeAllListeners();
+                state.player.stop();
+                state.player = null;
+            }
+            state.queue = [];
+
+            // Join voice channel
+            const connection = joinVoiceChannel({
+                channelId: channelId,
+                guildId: guild.id,
+                adapterCreator: guild.voiceAdapterCreator,
+            });
+            state.connection = connection;
+
+            // Wait for connection to be ready
+            if (connection.state.status !== VoiceConnectionStatus.Ready) {
+                await entersState(connection, VoiceConnectionStatus.Ready, 10_000);
+            }
+
+            // Create player and play crew theme
+            const player = createAudioPlayer();
+            state.player = player;
+
+            const songFile = allFiles[0];
+            const songName = path.parse(songFile).name;
+            const resource = createAudioResource(path.join(targetFolder, songFile));
+
+            // Auto-stop and disconnect when song finishes
+            player.once(AudioPlayerStatus.Idle, () => {
+                console.log(`Crew theme for "${matchedCrew}" finished, disconnecting.`);
+                player.stop();
+                state.player = null;
+                if (state.connection) {
+                    state.connection.destroy();
+                    state.connection = null;
+                }
+            });
+
+            // Error handler also cleans up
+            player.once('error', (error) => {
+                console.error(`Error playing crew theme for "${matchedCrew}":`, error);
+                player.stop();
+                state.player = null;
+                if (state.connection) {
+                    state.connection.destroy();
+                    state.connection = null;
+                }
+            });
+
+            connection.subscribe(player);
+            player.play(resource);
+
+            res.json({
+                success: true,
+                crew: matchedCrew,
+                song: songName,
+                message: `Now playing ${matchedCrew} crew theme: ${songName}`,
+            });
+        } catch (err) {
+            console.error('API /play-crew error:', err);
+            // Clean up on unexpected error
+            if (state.player) {
+                state.player.removeAllListeners();
+                state.player.stop();
+                state.player = null;
+            }
+            if (state.connection) {
+                state.connection.destroy();
+                state.connection = null;
+            }
             res.status(500).json({ error: err.message });
         }
     });

--- a/src/commands/crew.js
+++ b/src/commands/crew.js
@@ -12,6 +12,8 @@ const CREWS = [
 ];
 
 module.exports = {
+    CREWS,
+    crewFolder,
     data: new SlashCommandBuilder()
         .setName('crew')
         .setDescription('Plays a crew theme song')


### PR DESCRIPTION
## Summary
- Adds `POST /play-crew` HTTP endpoint to trigger crew theme song playback in Discord voice channel
- Exports `CREWS` array and `crewFolder` path from `src/commands/crew.js` for reuse by the API
- Auto-stops playback and disconnects from voice channel when the song finishes

## Details
- **Crew validation**: Case-insensitive matching against the canonical CREWS list; returns `validCrews` on mismatch
- **Playback lifecycle**: Interrupts any existing playback, joins voice channel, plays theme, auto-disconnects on `AudioPlayerStatus.Idle`
- **Error handling**: Cleans up player and connection state on both expected completion and errors
- **API contract**: `{ "crew": "Ops" }` -> `{ success, crew, song, message }`

## Integration
For use with Google Apps Scripts end-of-call automation to play crew theme songs at the end of community calls.

## Test plan
- [ ] POST with empty body -> 400 with validCrews list
- [ ] POST with invalid crew name -> 400 with error and validCrews
- [ ] POST with lowercase crew name (e.g., "ops") -> 200, plays correctly
- [ ] POST without auth header -> 401
- [ ] Successful playback -> joins channel, plays song, auto-disconnects when done
- [ ] While mixtape is playing -> stops mixtape, plays crew theme instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)